### PR TITLE
CI: build via penguin-tools Nix; tag-only releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,9 @@
-name: Compile and Publish Busybox
+name: Tag and Publish release
+
+# busybox is no longer cross-built here -- penguin-tools builds it for every
+# guest arch from this source (github:rehosting/penguin-tools#busybox-*) and
+# ships it in penguin-tools.tar.gz. This workflow only cuts a versioned release
+# for tracking/provenance; it publishes no binary asset.
 
 on:
   push:
@@ -6,34 +11,20 @@ on:
       - master
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
       - name: Get next version
         uses: reecetech/version-increment@2023.10.1
         id: version
         with:
           use_api: true
 
-      - name: Build 
-        run: |
-          git submodule update --init
-          docker run --rm -v $PWD:/app -w /app ghcr.io/rehosting/embedded-toolchains:latest /app/build.sh
-          tar -czvf busybox-latest.tar.gz build
-
-      - name: Save package
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: busybox
-          path: build
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Create release
         id: create_release
@@ -45,18 +36,11 @@ jobs:
           release_name: Release ${{ steps.version.outputs.v-version }} ${{ github.ref }}
           body: |
             Release ${{ steps.version.outputs.v-version }} @${{ github.ref }}
+
+            Binaries are built and distributed by penguin-tools
+            (penguin-tools.tar.gz); this release carries no binary asset.
           draft: true
           prerelease: false
-
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./busybox-latest.tar.gz
-          asset_name: busybox-latest.tar.gz
-          asset_content_type: application/gzip
 
       - name: Publish release
         uses: StuYarrow/publish-release@v1.1.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,52 @@
+name: Check that the code compiles
+
+# Build busybox for every guest arch through the penguin-tools Nix cross matrix
+# (the same machinery that ships it in penguin-tools.tar.gz), compiling *this*
+# checkout via --override-input. penguin-tools supplies the libhc header from its
+# own input, so the submodule is not needed here.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: rehosting-arc
+    env:
+      USER: runner
+      LOGNAME: runner
+      TMPDIR: /home/runner/_work/_temp
+      XDG_CACHE_HOME: /home/runner/_work/.cache
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare runner directories
+        run: mkdir -p "$TMPDIR" "$XDG_CACHE_HOME"
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y curl jq xz-utils
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            max-jobs = 8
+            cores = 8
+
+      - name: Configure Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: rehosting-tools
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          skipPush: ${{ github.event_name == 'pull_request' }}
+
+      - name: Build busybox for all guest arches (this checkout)
+        run: |
+          set -eux
+          for a in x86_64 armel aarch64 mipsel mipseb mips64el mips64eb \
+                   powerpc64 powerpc64le riscv64 loongarch64; do
+            nix build --accept-flake-config \
+              "github:rehosting/penguin-tools#busybox-$a" \
+              --override-input busybox "path:$PWD" \
+              --no-link --print-out-paths -L
+          done


### PR DESCRIPTION
Stop cross-building busybox in this repo's CI; penguin-tools builds it for every guest arch (`github:rehosting/penguin-tools#busybox-<arch>`) and ships it in `penguin-tools.tar.gz`.

- **tests.yml** (new PR check): builds busybox for all guest arches through the penguin-tools flake with `--override-input busybox` = this checkout. penguin-tools supplies the `libhc` header from its own input, so the submodule isn't needed.
- **build.yml** (release): versioned tag/release only, **no binary asset** (drops the embedded-toolchains Docker build).

Part of the guest-tool nixification (penguin-tools#11, merged).