### PR TITLE
portalcall: gate shell-coverage hypercalls on IGLOO_NO_SHELL_COV

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,12 +41,24 @@ jobs:
           skipPush: ${{ github.event_name == 'pull_request' }}
 
       - name: Build busybox for all guest arches (this checkout)
+        env:
+          # install-nix-action's github_access_token isn't honored on this
+          # pre-installed-nix runner, so the GitHub flake fetcher went out
+          # anonymous and hit the 60/hr shared-IP limit (HTTP 429). Authenticate
+          # the fetcher directly via NIX_CONFIG (public repo, so any valid token
+          # lifts the limit to 5000/hr).
+          NIX_CONFIG: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eux
+          # Resolve penguin-tools once instead of re-resolving HEAD for all 11
+          # arches, then build each against that pinned rev.
+          rev=$(nix flake metadata github:rehosting/penguin-tools \
+                  --json --refresh | jq -r .revision)
           for a in x86_64 armel aarch64 mipsel mipseb mips64el mips64eb \
                    powerpc64 powerpc64le riscv64 loongarch64; do
             nix build --accept-flake-config \
-              "github:rehosting/penguin-tools#busybox-$a" \
+              "github:rehosting/penguin-tools/$rev#busybox-$a" \
               --override-input busybox "path:$PWD" \
               --no-link --print-out-paths -L
           done

--- a/include/portalcall.h
+++ b/include/portalcall.h
@@ -19,11 +19,34 @@ static inline unsigned long portal_call(unsigned long user_magic, int argc,
 }
 
 #ifdef MAGIC_VALUE
+#include <stdlib.h>  /* getenv */
 #define RETRY 0xDEADBEEF
+
+/*
+ * Shell-coverage hypercalls are emitted only for the firmware-under-analysis.
+ * Penguin exports IGLOO_NO_SHELL_COV=1 in its own infrastructure environment
+ * (boot machinery + the vpnguin/console/guesthopper helpers) and clears it at
+ * the handoff into the firmware init, so everything in the infra environment
+ * stays silent. The marker is inherited across fork/exec, so the whole infra
+ * subtree -- including fork-without-exec subshells -- is covered without any
+ * per-process tracking on the host. Absence of the marker means "report", so a
+ * plain busybox outside Penguin behaves exactly as before.
+ */
+static inline int igloo_shell_cov_suppressed(void)
+{
+    static int cached = -1;
+    if (cached < 0)
+        cached = getenv("IGLOO_NO_SHELL_COV") != NULL;
+    return cached;
+}
+
 static inline int portal_hc(int hc_type, void **s, int len)
 {
     uint64_t ret = hc_type;
     int y = 0;
+
+    if (igloo_shell_cov_suppressed())
+        return 0;
     do {
         ret = MAGIC_VALUE;
         volatile int x = 0;


### PR DESCRIPTION
## What

`portal_hc()` — the single `#ifdef MAGIC_VALUE` choke point through which all six shell-coverage emitters flow — now returns early when the `IGLOO_NO_SHELL_COV` environment variable is set (cached `getenv`).

## Why

Shell coverage was being scoped to the firmware-under-analysis on the **host** via a pid set seeded from exec events. That set was lossy (fork-without-exec subshells were missed), unbounded (never pruned → PID-reuse drift), and a host/driver split. Moving the gate into the guest via an inherited env marker fixes all three by construction:

- inherited across fork/exec → whole infra subtree covered, including subshells
- no host state to grow or get stale
- no driver round-trip

Penguin sets the marker in its infrastructure environment and clears it at the firmware handoff (separate penguin PR). **Absence of the marker = report**, so a plain busybox outside Penguin behaves exactly as before.

Pairs with penguin (sets/clears the marker, bumps `BUSYBOX_VERSION`) and igloo_driver #85 (netbinds always reports).